### PR TITLE
deps: revert to graphql-relay v0.9.0, remove DT types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "class-validator": "^0.13.1",
-        "graphql-relay": "^0.10.0",
+        "graphql-relay": "^0.9.0",
         "joi": "^17.2.0",
         "query-string": "7.1.1"
       },
@@ -18,7 +18,6 @@
         "@nestjs/common": "8.2.6",
         "@nestjs/core": "8.2.6",
         "@nestjs/graphql": "10.0.2",
-        "@types/graphql-relay": "0.6.0",
         "@types/jest": "27.4.0",
         "@types/node": "16.11.24",
         "@typescript-eslint/eslint-plugin": "5.11.0",
@@ -1478,24 +1477,6 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/graphql-relay": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/graphql-relay/-/graphql-relay-0.6.0.tgz",
-      "integrity": "sha512-/o2GDW22mdggQ9PUSNMbYFJMrCMwwiX8uu1/xS1rbDEdcC6+OVBy9Uz5ePW2zLDzhOznh3Ozm5t09jHqaY8cuw==",
-      "dev": true,
-      "dependencies": {
-        "graphql": "^14.5.3 || ^15.0.0"
-      }
-    },
-    "node_modules/@types/graphql-relay/node_modules/graphql": {
-      "version": "15.8.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.x"
       }
     },
     "node_modules/@types/http-cache-semantics": {
@@ -4284,23 +4265,23 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
-      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "peer": true,
       "engines": {
-        "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
+        "node": ">= 10.x"
       }
     },
     "node_modules/graphql-relay": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.10.0.tgz",
-      "integrity": "sha512-44yBuw2/DLNEiMypbNZBt1yMDbBmyVPVesPywnteGGALiBmdyy1JP8jSg8ClLePg8ZZxk0O4BLhd1a6U/1jDOQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.9.0.tgz",
+      "integrity": "sha512-yNJLCqcjz0XpzpmmckRJCSK8a2ZLwTurwrQ09UyGftONh52PbrGpK1UO4yspvj0c7pC+jkN4ZUqVXG3LRrWkXQ==",
       "engines": {
         "node": "^12.20.0 || ^14.15.0 || >= 15.9.0"
       },
       "peerDependencies": {
-        "graphql": "^16.2.0"
+        "graphql": "^15.5.3"
       }
     },
     "node_modules/graphql-tag": {
@@ -11235,23 +11216,6 @@
         "@types/node": "*"
       }
     },
-    "@types/graphql-relay": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@types/graphql-relay/-/graphql-relay-0.6.0.tgz",
-      "integrity": "sha512-/o2GDW22mdggQ9PUSNMbYFJMrCMwwiX8uu1/xS1rbDEdcC6+OVBy9Uz5ePW2zLDzhOznh3Ozm5t09jHqaY8cuw==",
-      "dev": true,
-      "requires": {
-        "graphql": "^14.5.3 || ^15.0.0"
-      },
-      "dependencies": {
-        "graphql": {
-          "version": "15.8.0",
-          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
-          "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
-          "dev": true
-        }
-      }
-    },
     "@types/http-cache-semantics": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
@@ -13328,15 +13292,15 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.3.0.tgz",
-      "integrity": "sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "peer": true
     },
     "graphql-relay": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.10.0.tgz",
-      "integrity": "sha512-44yBuw2/DLNEiMypbNZBt1yMDbBmyVPVesPywnteGGALiBmdyy1JP8jSg8ClLePg8ZZxk0O4BLhd1a6U/1jDOQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.9.0.tgz",
+      "integrity": "sha512-yNJLCqcjz0XpzpmmckRJCSK8a2ZLwTurwrQ09UyGftONh52PbrGpK1UO4yspvj0c7pC+jkN4ZUqVXG3LRrWkXQ==",
       "requires": {}
     },
     "graphql-tag": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "class-validator": "^0.13.1",
-    "graphql-relay": "^0.10.0",
+    "graphql-relay": "^0.9.0",
     "joi": "^17.2.0",
     "query-string": "7.1.1"
   },
@@ -34,7 +34,6 @@
     "@nestjs/common": "8.2.6",
     "@nestjs/core": "8.2.6",
     "@nestjs/graphql": "10.0.2",
-    "@types/graphql-relay": "0.6.0",
     "@types/jest": "27.4.0",
     "@types/node": "16.11.24",
     "@typescript-eslint/eslint-plugin": "5.11.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "class-validator": "^0.13.1",
     "graphql-relay": "^0.9.0",
     "joi": "^17.2.0",
-    "query-string": "7.1.1"
+    "query-string": "^7.1.1"
   },
   "devDependencies": {
     "@nestjs/common": "8.2.6",


### PR DESCRIPTION
graphql-relay 0.10.0 requires graphql v16.x, we're not ready for that yet.