### PR TITLE
feat: allow passing edges directly to ConnectionBuilder.build()

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ export class PersonConnectionBuilder extends ConnectionBuilder<
     // A cursor sent to or received from a client is represented as a base64-encoded, URL-style query string containing
     // one or more key/value pairs describing the referenced node's position in the result set (its ID, a date, etc.)
     // Validation is optional, but recommended to enforce that cursor values supplied by clients must be well-formed.
-    // See documentation for Joi at https://joi.dev/api/?v=17#object
+    // This example uses Joi for validation, see documentation at https://joi.dev/api/?v=17#object
     // The following schema accepts only an object matching the type { id: string }:
     const schema: Joi.ObjectSchema<PersonCursorParams> = Joi.object({
       id: Joi.string().empty('').required(),

--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ Now define a `ConnectionBuilder` class for your `Connection` object. The builder
 pagination arguments for the connection, and creating the cursors and `Edge` objects that make up the connection.
 
 ```ts
-import { ConnectionBuilder, Cursor, PageInfo, validateParamsUsingSchema } from 'nestjs-graphql-connection';
+import {
+  ConnectionBuilder,
+  Cursor,
+  EdgeInputWithCursor,
+  PageInfo,
+  validateParamsUsingSchema,
+} from 'nestjs-graphql-connection';
 
 export type PersonCursorParams = { id: string };
 export type PersonCursor = Cursor<PersonCursorParams>;
@@ -96,7 +102,7 @@ export class PersonConnectionBuilder extends ConnectionBuilder<
     return new PersonConnection(fields);
   }
 
-  public createEdge(fields: { node: TestNode; cursor: string }): TestEdge {
+  public createEdge(fields: EdgeInputWithCursor<PersonEdge>): PersonEdge {
     return new PersonEdge(fields);
   }
 
@@ -168,7 +174,12 @@ determining what the last result was on page 9.
 To use offset cursors, extend your builder class from `OffsetPaginatedConnectionBuilder` instead of `ConnectionBuilder`:
 
 ```ts
-import { OffsetPaginatedConnectionBuilder, PageInfo, validateParamsUsingSchema } from 'nestjs-graphql-connection';
+import {
+  EdgeInputWithCursor,
+  OffsetPaginatedConnectionBuilder,
+  PageInfo,
+  validateParamsUsingSchema,
+} from 'nestjs-graphql-connection';
 
 export class PersonConnectionBuilder extends OffsetPaginatedConnectionBuilder<
   PersonConnection,
@@ -180,7 +191,7 @@ export class PersonConnectionBuilder extends OffsetPaginatedConnectionBuilder<
     return new PersonConnection(fields);
   }
 
-  public createEdge(fields: { node: TestNode; cursor: string }): TestEdge {
+  public createEdge(fields: EdgeInputWithCursor<PersonEdge>): PersonEdge {
     return new PersonEdge(fields);
   }
 

--- a/README.md
+++ b/README.md
@@ -247,17 +247,25 @@ properties -- such as the date that the friend was added, or the type of relatio
 this is analogous to having a Many-to-Many relation where the intermediate join table contains additional data columns
 beyond just the keys of the two joined tables.)
 
-In this case your edge type would look like the following example. Notice that we pass a `{ createdAt: Date }` type
-argument to `createEdgeType`; this specifies typings for the fields that are allowed to be passed to your edge class's
-constructor for initialization when doing `new PersonFriendEdge({ ...fields })`.
+In this case your edge type would look like the following example. Notice that we also now define a
+`PersonFriendEdgeInterface` type which we pass as a generic argument to `createEdgeType`; this ensures correct typings
+for the fields that are allowed to be passed to your edge class's constructor for initialization when doing
+`new PersonFriendEdge({ ...fields })`.
 
 ```ts
 import { Field, GraphQLISODateTime, ObjectType } from '@nestjs/graphql';
-import { createEdgeType } from 'nestjs-graphql-connection';
+import { createEdgeType, EdgeInterface } from 'nestjs-graphql-connection';
 import { Person } from './entities';
 
+export interface PersonFriendEdgeInterface extends EdgeInterface<Person> {
+  createdAt: Date;
+}
+
 @ObjectType()
-export class PersonFriendEdge extends createEdgeType<{ createdAt: Date }>(Person) {
+export class PersonFriendEdge
+  extends createEdgeType<PersonFriendEdgeInterface>(Person)
+  implements PersonFriendEdgeInterface
+{
   @Field(type => GraphQLISODateTime)
   public createdAt: Date;
 }

--- a/src/builder/ConnectionBuilder.spec.ts
+++ b/src/builder/ConnectionBuilder.spec.ts
@@ -1,7 +1,14 @@
 import Joi from 'joi';
 import { Cursor } from '../cursor/Cursor';
 import { validateParamsUsingSchema } from '../cursor/validateParamsUsingSchema';
-import { ConnectionArgs, createConnectionType, createEdgeType, PageInfo } from '../type';
+import {
+  ConnectionArgs,
+  ConnectionInterface,
+  createConnectionType,
+  createEdgeType,
+  EdgeInterface,
+  PageInfo,
+} from '../type';
 import { ConnectionBuilder, EdgeInputWithCursor } from './ConnectionBuilder';
 
 class TestNode {
@@ -9,11 +16,22 @@ class TestNode {
   name: string;
 }
 
-class TestEdge extends createEdgeType<{ customEdgeField?: number }>(TestNode) {
+interface TestEdgeInterface extends EdgeInterface<TestNode> {
+  customEdgeField?: number;
+}
+
+class TestEdge extends createEdgeType<TestEdgeInterface>(TestNode) implements TestEdgeInterface {
   public customEdgeField?: number;
 }
 
-class TestConnection extends createConnectionType<{ customConnectionField?: number }>(TestEdge) {
+interface TestConnectionInterface extends ConnectionInterface<TestEdge> {
+  customConnectionField?: number;
+}
+
+class TestConnection
+  extends createConnectionType<TestConnectionInterface>(TestEdge)
+  implements TestConnectionInterface
+{
   public customConnectionField?: number;
 }
 

--- a/src/builder/ConnectionBuilder.spec.ts
+++ b/src/builder/ConnectionBuilder.spec.ts
@@ -271,4 +271,37 @@ describe('ConnectionBuilder', () => {
       ],
     });
   });
+
+  test('Can build Connection using partial Edges', () => {
+    const builder = new TestConnectionBuilder({
+      first: 5,
+    });
+    const connection = builder.build({
+      totalEdges: 12,
+      edges: [
+        { node: { id: 'node1', name: 'A' }, customEdgeField: 1 },
+        { node: { id: 'node2', name: 'B' }, customEdgeField: 2 },
+        { node: { id: 'node3', name: 'C' }, customEdgeField: 3 },
+        { node: { id: 'node4', name: 'D' }, customEdgeField: 4 },
+        { node: { id: 'node5', name: 'E' }, customEdgeField: 5 },
+      ],
+    });
+
+    expect(connection).toMatchObject({
+      pageInfo: {
+        totalEdges: 12,
+        hasNextPage: true,
+        hasPreviousPage: false,
+        startCursor: new Cursor({ id: 'node1' }).encode(),
+        endCursor: new Cursor({ id: 'node5' }).encode(),
+      },
+      edges: [
+        { node: { id: 'node1', name: 'A' }, cursor: new Cursor({ id: 'node1' }).encode(), customEdgeField: 1 },
+        { node: { id: 'node2', name: 'B' }, cursor: new Cursor({ id: 'node2' }).encode(), customEdgeField: 2 },
+        { node: { id: 'node3', name: 'C' }, cursor: new Cursor({ id: 'node3' }).encode(), customEdgeField: 3 },
+        { node: { id: 'node4', name: 'D' }, cursor: new Cursor({ id: 'node4' }).encode(), customEdgeField: 4 },
+        { node: { id: 'node5', name: 'E' }, cursor: new Cursor({ id: 'node5' }).encode(), customEdgeField: 5 },
+      ],
+    });
+  });
 });

--- a/src/builder/ConnectionBuilder.spec.ts
+++ b/src/builder/ConnectionBuilder.spec.ts
@@ -2,7 +2,7 @@ import Joi from 'joi';
 import { Cursor } from '../cursor/Cursor';
 import { validateParamsUsingSchema } from '../cursor/validateParamsUsingSchema';
 import { ConnectionArgs, createConnectionType, createEdgeType, PageInfo } from '../type';
-import { ConnectionBuilder } from './ConnectionBuilder';
+import { ConnectionBuilder, EdgeInputWithCursor } from './ConnectionBuilder';
 
 class TestNode {
   id: string;
@@ -36,7 +36,7 @@ class TestConnectionBuilder extends ConnectionBuilder<
     return new TestConnection(fields);
   }
 
-  public createEdge(fields: { node: TestNode; cursor: string }): TestEdge {
+  public createEdge(fields: EdgeInputWithCursor<TestEdge>): TestEdge {
     return new TestEdge(fields);
   }
 

--- a/src/builder/ConnectionBuilder.ts
+++ b/src/builder/ConnectionBuilder.ts
@@ -8,6 +8,18 @@ export interface ConnectionBuilderOptions {
   allowReverseOrder?: boolean;
 }
 
+export type EdgeExtraFields<TEdge extends EdgeInterface<TNode>, TNode = any> = Partial<Omit<TEdge, 'node' | 'cursor'>>;
+
+export type EdgeInput<TEdge extends EdgeInterface<TNode>, TNode = any> = {
+  node: TNode;
+  cursor?: string;
+} & EdgeExtraFields<TEdge>;
+
+export type EdgeInputWithCursor<TEdge extends EdgeInterface<TNode>, TNode = any> = {
+  node: TNode;
+  cursor: string;
+} & EdgeExtraFields<TEdge>;
+
 interface CommonBuildParams<
   TNode,
   TEdge extends EdgeInterface<TNode>,
@@ -18,7 +30,7 @@ interface CommonBuildParams<
   hasNextPage?: boolean;
   hasPreviousPage?: boolean;
   createConnection?: (fields: { edges: TEdge[]; pageInfo: PageInfo }) => TConnection;
-  createEdge?: (fields: { node: TNode; cursor: string } & Partial<Omit<TEdge, 'node' | 'cursor'>>) => TEdge;
+  createEdge?: (fields: EdgeInputWithCursor<TEdge>) => TEdge;
   createCursor?: (node: TNode, index: number) => TCursor;
 }
 
@@ -39,7 +51,7 @@ type BuildFromEdgesParams<
   TCursor extends Cursor = Cursor,
 > = {
   nodes?: never;
-  edges?: ({ node: TNode } & Partial<Omit<TEdge, 'node'>>)[];
+  edges?: EdgeInput<TEdge>[];
 } & CommonBuildParams<TNode, TEdge, TConnection, TCursor>;
 
 export abstract class ConnectionBuilder<
@@ -62,7 +74,7 @@ export abstract class ConnectionBuilder<
 
   public abstract createConnection(fields: { edges: TEdge[]; pageInfo: PageInfo }): TConnection;
 
-  public abstract createEdge(fields: { node: TNode; cursor: string } & Partial<Omit<TEdge, 'node' | 'cursor'>>): TEdge;
+  public abstract createEdge(fields: EdgeInputWithCursor<TEdge>): TEdge;
 
   public abstract createCursor(node: TNode, index: number): TCursor;
 

--- a/src/builder/ConnectionBuilder.ts
+++ b/src/builder/ConnectionBuilder.ts
@@ -8,6 +8,40 @@ export interface ConnectionBuilderOptions {
   allowReverseOrder?: boolean;
 }
 
+interface CommonBuildParams<
+  TNode,
+  TEdge extends EdgeInterface<TNode>,
+  TConnection extends ConnectionInterface<TEdge>,
+  TCursor extends Cursor = Cursor,
+> {
+  totalEdges?: number;
+  hasNextPage?: boolean;
+  hasPreviousPage?: boolean;
+  createConnection?: (fields: { edges: TEdge[]; pageInfo: PageInfo }) => TConnection;
+  createEdge?: (fields: { node: TNode; cursor: string } & Partial<Omit<TEdge, 'node' | 'cursor'>>) => TEdge;
+  createCursor?: (node: TNode, index: number) => TCursor;
+}
+
+type BuildFromNodesParams<
+  TNode,
+  TEdge extends EdgeInterface<TNode>,
+  TConnection extends ConnectionInterface<TEdge>,
+  TCursor extends Cursor = Cursor,
+> = {
+  nodes?: TNode[];
+  edges?: never;
+} & CommonBuildParams<TNode, TEdge, TConnection, TCursor>;
+
+type BuildFromEdgesParams<
+  TNode,
+  TEdge extends EdgeInterface<TNode>,
+  TConnection extends ConnectionInterface<TEdge>,
+  TCursor extends Cursor = Cursor,
+> = {
+  nodes?: never;
+  edges?: ({ node: TNode } & Partial<Omit<TEdge, 'node'>>)[];
+} & CommonBuildParams<TNode, TEdge, TConnection, TCursor>;
+
 export abstract class ConnectionBuilder<
   TConnection extends ConnectionInterface<TEdge>,
   TConnectionArgs extends ConnectionArgs,
@@ -28,7 +62,7 @@ export abstract class ConnectionBuilder<
 
   public abstract createConnection(fields: { edges: TEdge[]; pageInfo: PageInfo }): TConnection;
 
-  public abstract createEdge(fields: { node: TNode; cursor: string }): TEdge;
+  public abstract createEdge(fields: { node: TNode; cursor: string } & Partial<Omit<TEdge, 'node' | 'cursor'>>): TEdge;
 
   public abstract createCursor(node: TNode, index: number): TCursor;
 
@@ -58,34 +92,37 @@ export abstract class ConnectionBuilder<
 
   public build({
     nodes,
+    edges,
     totalEdges,
     hasNextPage,
     hasPreviousPage,
     createConnection = this.createConnection,
     createEdge = this.createEdge,
     createCursor = this.createCursor,
-  }: {
-    nodes: TNode[];
-    totalEdges?: number;
-    hasNextPage?: boolean;
-    hasPreviousPage?: boolean;
-    createConnection?: (fields: { edges: TEdge[]; pageInfo: PageInfo }) => TConnection;
-    createEdge?: (fields: { node: TNode; cursor: string }) => TEdge;
-    createCursor?: (node: TNode, index: number) => TCursor;
-  }): TConnection {
-    const edges = nodes.map((node, index) =>
-      createEdge.bind(this)({
-        node,
-        cursor: createCursor.bind(this)(node, index).encode(),
-      }),
-    );
+  }:
+    | BuildFromNodesParams<TNode, TEdge, TConnection, TCursor>
+    | BuildFromEdgesParams<TNode, TEdge, TConnection, TCursor>): TConnection {
+    const resolvedEdges: TEdge[] =
+      edges != null
+        ? edges.map((edge, index) =>
+            createEdge.bind(this)({
+              cursor: edge.cursor ?? createCursor.bind(this)(edge.node, index).encode(),
+              ...edge,
+            }),
+          )
+        : nodes!.map((node, index) =>
+            createEdge.bind(this)({
+              node,
+              cursor: createCursor.bind(this)(node, index).encode(),
+            }),
+          );
 
     return createConnection.bind(this)({
-      edges,
+      edges: resolvedEdges,
       pageInfo: this.createPageInfo({
-        edges,
+        edges: resolvedEdges,
         totalEdges,
-        hasNextPage: hasNextPage ?? (totalEdges != null && totalEdges > edges.length),
+        hasNextPage: hasNextPage ?? (totalEdges != null && totalEdges > resolvedEdges.length),
         hasPreviousPage: hasPreviousPage ?? (this.afterCursor != null || this.beforeCursor != null),
       }),
     });


### PR DESCRIPTION
This makes it easier to build a connection with edges that have additional metadata fields.