### PR TITLE
feat: allow Node to have any graphql type in createEdgeType()

### DIFF
--- a/src/builder/ConnectionBuilder.spec.ts
+++ b/src/builder/ConnectionBuilder.spec.ts
@@ -1,79 +1,9 @@
-import Joi from 'joi';
 import { Cursor } from '../cursor/Cursor';
-import { validateParamsUsingSchema } from '../cursor/validateParamsUsingSchema';
-import {
-  ConnectionArgs,
-  ConnectionInterface,
-  createConnectionType,
-  createEdgeType,
-  EdgeInterface,
-  PageInfo,
-} from '../type';
-import { ConnectionBuilder, EdgeInputWithCursor } from './ConnectionBuilder';
-
-class TestNode {
-  id: string;
-  name: string;
-}
-
-interface TestEdgeInterface extends EdgeInterface<TestNode> {
-  customEdgeField?: number;
-}
-
-class TestEdge extends createEdgeType<TestEdgeInterface>(TestNode) implements TestEdgeInterface {
-  public customEdgeField?: number;
-}
-
-interface TestConnectionInterface extends ConnectionInterface<TestEdge> {
-  customConnectionField?: number;
-}
-
-class TestConnection
-  extends createConnectionType<TestConnectionInterface>(TestEdge)
-  implements TestConnectionInterface
-{
-  public customConnectionField?: number;
-}
-
-class TestConnectionArgs extends ConnectionArgs {
-  public sortOption?: string;
-}
-
-type TestCursorParams = { id?: string; name?: string };
-
-type TestCursor = Cursor<TestCursorParams>;
-
-class TestConnectionBuilder extends ConnectionBuilder<
-  TestConnection,
-  TestConnectionArgs,
-  TestEdge,
-  TestNode,
-  TestCursor
-> {
-  public createConnection(fields: { edges: TestEdge[]; pageInfo: PageInfo }): TestConnection {
-    return new TestConnection(fields);
-  }
-
-  public createEdge(fields: EdgeInputWithCursor<TestEdge>): TestEdge {
-    return new TestEdge(fields);
-  }
-
-  public createCursor(node: TestNode): TestCursor {
-    return new Cursor({ id: node.id });
-  }
-
-  public decodeCursor(encodedString: string): TestCursor {
-    const schema: Joi.ObjectSchema<TestCursorParams> = Joi.object({
-      id: Joi.string().empty('').required(),
-    }).unknown(false);
-
-    return Cursor.fromString(encodedString, params => validateParamsUsingSchema(params, schema));
-  }
-}
+import { Foo, FooConnection, FooConnectionBuilder, FooEdge } from '../../test/FooConnection';
 
 describe('ConnectionBuilder', () => {
   test('First page is built correctly', () => {
-    const builder = new TestConnectionBuilder({
+    const builder = new FooConnectionBuilder({
       first: 5,
     });
 
@@ -84,11 +14,11 @@ describe('ConnectionBuilder', () => {
     const connection = builder.build({
       totalEdges: 12,
       nodes: [
-        { id: 'node1', name: 'A' },
-        { id: 'node2', name: 'B' },
-        { id: 'node3', name: 'C' },
-        { id: 'node4', name: 'D' },
-        { id: 'node5', name: 'E' },
+        new Foo({ id: 'node1', name: 'A' }),
+        new Foo({ id: 'node2', name: 'B' }),
+        new Foo({ id: 'node3', name: 'C' }),
+        new Foo({ id: 'node4', name: 'D' }),
+        new Foo({ id: 'node5', name: 'E' }),
       ],
     });
 
@@ -111,7 +41,7 @@ describe('ConnectionBuilder', () => {
   });
 
   test('Second page is built correctly', () => {
-    const builder = new TestConnectionBuilder({
+    const builder = new FooConnectionBuilder({
       first: 5,
       after: new Cursor({ id: 'node5' }).encode(),
     });
@@ -123,11 +53,11 @@ describe('ConnectionBuilder', () => {
     const connection = builder.build({
       totalEdges: 12,
       nodes: [
-        { id: 'node6', name: 'F' },
-        { id: 'node7', name: 'G' },
-        { id: 'node8', name: 'H' },
-        { id: 'node9', name: 'I' },
-        { id: 'node10', name: 'J' },
+        new Foo({ id: 'node6', name: 'F' }),
+        new Foo({ id: 'node7', name: 'G' }),
+        new Foo({ id: 'node8', name: 'H' }),
+        new Foo({ id: 'node9', name: 'I' }),
+        new Foo({ id: 'node10', name: 'J' }),
       ],
     });
 
@@ -150,7 +80,7 @@ describe('ConnectionBuilder', () => {
   });
 
   test('Last page is built correctly', () => {
-    const builder = new TestConnectionBuilder({
+    const builder = new FooConnectionBuilder({
       first: 5,
       after: new Cursor({ id: 'node10' }).encode(),
     });
@@ -161,10 +91,7 @@ describe('ConnectionBuilder', () => {
 
     const connection = builder.build({
       totalEdges: 12,
-      nodes: [
-        { id: 'node11', name: 'K' },
-        { id: 'node12', name: 'L' },
-      ],
+      nodes: [new Foo({ id: 'node11', name: 'K' }), new Foo({ id: 'node12', name: 'L' })],
       hasNextPage: false, // must be set explicitly when using Cursor pagination
     });
 
@@ -184,7 +111,7 @@ describe('ConnectionBuilder', () => {
   });
 
   test('Empty result is built correctly', () => {
-    const builder = new TestConnectionBuilder({
+    const builder = new FooConnectionBuilder({
       first: 5,
     });
 
@@ -210,23 +137,23 @@ describe('ConnectionBuilder', () => {
   });
 
   test('Can override createConnection and createEdge when building Connection', () => {
-    const builder = new TestConnectionBuilder({
+    const builder = new FooConnectionBuilder({
       first: 5,
     });
     const connection = builder.build({
       totalEdges: 12,
       nodes: [
-        { id: 'node1', name: 'A' },
-        { id: 'node2', name: 'B' },
-        { id: 'node3', name: 'C' },
-        { id: 'node4', name: 'D' },
-        { id: 'node5', name: 'E' },
+        new Foo({ id: 'node1', name: 'A' }),
+        new Foo({ id: 'node2', name: 'B' }),
+        new Foo({ id: 'node3', name: 'C' }),
+        new Foo({ id: 'node4', name: 'D' }),
+        new Foo({ id: 'node5', name: 'E' }),
       ],
       createConnection({ edges, pageInfo }) {
-        return new TestConnection({ edges, pageInfo, customConnectionField: 99 });
+        return new FooConnection({ edges, pageInfo, customConnectionField: 99 });
       },
       createEdge({ node, cursor }) {
-        return new TestEdge({ node, cursor, customEdgeField: 99 });
+        return new FooEdge({ node, cursor, customEdgeField: 99 });
       },
     });
 
@@ -250,20 +177,20 @@ describe('ConnectionBuilder', () => {
   });
 
   test('Can override createCursor using connectionArgs when building Connection', () => {
-    const builder = new TestConnectionBuilder({
+    const builder = new FooConnectionBuilder({
       first: 5,
       sortOption: 'name',
     });
     const connection = builder.build({
       totalEdges: 12,
       nodes: [
-        { id: 'node1', name: 'A' },
-        { id: 'node2', name: 'B' },
-        { id: 'node3', name: 'C' },
-        { id: 'node4', name: 'D' },
-        { id: 'node5', name: 'E' },
+        new Foo({ id: 'node1', name: 'A' }),
+        new Foo({ id: 'node2', name: 'B' }),
+        new Foo({ id: 'node3', name: 'C' }),
+        new Foo({ id: 'node4', name: 'D' }),
+        new Foo({ id: 'node5', name: 'E' }),
       ],
-      createCursor(this: TestConnectionBuilder, node) {
+      createCursor(this: FooConnectionBuilder, node) {
         if (this.connectionArgs.sortOption === 'name') {
           return new Cursor({ name: node.name });
         }
@@ -291,17 +218,17 @@ describe('ConnectionBuilder', () => {
   });
 
   test('Can build Connection using partial Edges', () => {
-    const builder = new TestConnectionBuilder({
+    const builder = new FooConnectionBuilder({
       first: 5,
     });
     const connection = builder.build({
       totalEdges: 12,
       edges: [
-        { node: { id: 'node1', name: 'A' }, customEdgeField: 1 },
-        { node: { id: 'node2', name: 'B' }, customEdgeField: 2 },
-        { node: { id: 'node3', name: 'C' }, customEdgeField: 3 },
-        { node: { id: 'node4', name: 'D' }, customEdgeField: 4 },
-        { node: { id: 'node5', name: 'E' }, customEdgeField: 5 },
+        { node: new Foo({ id: 'node1', name: 'A' }), customEdgeField: 1 },
+        { node: new Foo({ id: 'node2', name: 'B' }), customEdgeField: 2 },
+        { node: new Foo({ id: 'node3', name: 'C' }), customEdgeField: 3 },
+        { node: new Foo({ id: 'node4', name: 'D' }), customEdgeField: 4 },
+        { node: new Foo({ id: 'node5', name: 'E' }), customEdgeField: 5 },
       ],
     });
 

--- a/src/builder/ConnectionBuilder.spec.ts
+++ b/src/builder/ConnectionBuilder.spec.ts
@@ -1,5 +1,6 @@
 import { Cursor } from '../cursor/Cursor';
 import { Foo, FooConnection, FooConnectionBuilder, FooEdge } from '../../test/FooConnection';
+import { BarConnectionBuilder, FruitBar, NutBar } from '../../test/BarConnection';
 
 describe('ConnectionBuilder', () => {
   test('First page is built correctly', () => {
@@ -246,6 +247,39 @@ describe('ConnectionBuilder', () => {
         { node: { id: 'node3', name: 'C' }, cursor: new Cursor({ id: 'node3' }).encode(), customEdgeField: 3 },
         { node: { id: 'node4', name: 'D' }, cursor: new Cursor({ id: 'node4' }).encode(), customEdgeField: 4 },
         { node: { id: 'node5', name: 'E' }, cursor: new Cursor({ id: 'node5' }).encode(), customEdgeField: 5 },
+      ],
+    });
+  });
+
+  test('Can build Connection with Nodes having a union type', () => {
+    const builder = new BarConnectionBuilder({
+      first: 5,
+    });
+    const connection = builder.build({
+      totalEdges: 12,
+      nodes: [
+        new FruitBar({ id: 'node1', name: 'Apple', sugars: 123 }),
+        new FruitBar({ id: 'node2', name: 'Banana', sugars: 87 }),
+        new NutBar({ id: 'node3', name: 'Peanut', protein: 12 }),
+        new NutBar({ id: 'node4', name: 'Macadamia', protein: 23 }),
+        new FruitBar({ id: 'node5', name: 'Orange', sugars: 234 }),
+      ],
+    });
+
+    expect(connection).toMatchObject({
+      pageInfo: {
+        totalEdges: 12,
+        hasNextPage: true,
+        hasPreviousPage: false,
+        startCursor: new Cursor({ id: 'node1' }).encode(),
+        endCursor: new Cursor({ id: 'node5' }).encode(),
+      },
+      edges: [
+        { node: { id: 'node1', name: 'Apple', sugars: 123 }, cursor: new Cursor({ id: 'node1' }).encode() },
+        { node: { id: 'node2', name: 'Banana', sugars: 87 }, cursor: new Cursor({ id: 'node2' }).encode() },
+        { node: { id: 'node3', name: 'Peanut', protein: 12 }, cursor: new Cursor({ id: 'node3' }).encode() },
+        { node: { id: 'node4', name: 'Macadamia', protein: 23 }, cursor: new Cursor({ id: 'node4' }).encode() },
+        { node: { id: 'node5', name: 'Orange', sugars: 234 }, cursor: new Cursor({ id: 'node5' }).encode() },
       ],
     });
   });

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './ConnectionBuilder';
+export * from './OffsetPaginatedConnectionBuilder';

--- a/src/type/Connection.ts
+++ b/src/type/Connection.ts
@@ -1,4 +1,4 @@
-import * as GQL from '@nestjs/graphql';
+import { Field, ObjectType } from '@nestjs/graphql';
 import { Initializable } from 'ts-class-initializable';
 import { EdgeInterface } from './Edge';
 import { PageInfo } from './PageInfo';
@@ -17,15 +17,15 @@ export function createConnectionType<
   // This class should be further extended by concrete Connection types. It can't be marked as
   // an abstract class because TS lacks support for returning `abstract new()...` as a type
   // (https://github.com/Microsoft/TypeScript/issues/25606)
-  @GQL.ObjectType({ isAbstract: true })
+  @ObjectType({ isAbstract: true })
   class Connection
     extends Initializable<ConnectionInterface<TEdge> & TInitFields>
     implements ConnectionInterface<TEdge>
   {
-    @GQL.Field(_type => PageInfo)
+    @Field(_type => PageInfo)
     public pageInfo: PageInfo;
 
-    @GQL.Field(_type => [TEdgeClass])
+    @Field(_type => [TEdgeClass])
     public edges: TEdge[];
   }
 

--- a/src/type/ConnectionArgs.ts
+++ b/src/type/ConnectionArgs.ts
@@ -1,12 +1,12 @@
-import * as GQL from '@nestjs/graphql';
+import { ArgsType, Field, Int } from '@nestjs/graphql';
 import * as Validate from 'class-validator';
 
-@GQL.ArgsType()
+@ArgsType()
 export class ConnectionArgs {
   @Validate.IsInt()
   @Validate.Min(1)
   @Validate.IsOptional()
-  @GQL.Field(_type => GQL.Int, {
+  @Field(_type => Int, {
     nullable: true,
     description: 'Retrieve page of edges by fixed offset page number.',
   })
@@ -15,7 +15,7 @@ export class ConnectionArgs {
   @Validate.IsString()
   @Validate.MinLength(1)
   @Validate.IsOptional()
-  @GQL.Field(_type => String, {
+  @Field(_type => String, {
     nullable: true,
     description: 'Retrieve page of edges before opaque cursor.',
   })
@@ -24,7 +24,7 @@ export class ConnectionArgs {
   @Validate.IsString()
   @Validate.MinLength(1)
   @Validate.IsOptional()
-  @GQL.Field(_type => String, {
+  @Field(_type => String, {
     nullable: true,
     description: 'Retrieve page of edges after opaque cursor.',
   })
@@ -33,7 +33,7 @@ export class ConnectionArgs {
   @Validate.IsInt()
   @Validate.Min(1)
   @Validate.IsOptional()
-  @GQL.Field(_type => GQL.Int, {
+  @Field(_type => Int, {
     nullable: true,
     description: 'Retrieve first `n` edges.',
   })
@@ -42,7 +42,7 @@ export class ConnectionArgs {
   @Validate.IsInt()
   @Validate.Min(1)
   @Validate.IsOptional()
-  @GQL.Field(_type => GQL.Int, {
+  @Field(_type => Int, {
     nullable: true,
     description: 'Retrieve last `n` edges.',
   })

--- a/src/type/PageInfo.ts
+++ b/src/type/PageInfo.ts
@@ -1,19 +1,19 @@
-import * as GQL from '@nestjs/graphql';
+import { Field, Int, ObjectType } from '@nestjs/graphql';
 
-@GQL.ObjectType()
+@ObjectType()
 export class PageInfo {
-  @GQL.Field(_type => Boolean)
+  @Field(_type => Boolean)
   public hasNextPage!: boolean;
 
-  @GQL.Field(_type => Boolean)
+  @Field(_type => Boolean)
   public hasPreviousPage!: boolean;
 
-  @GQL.Field(_type => String, { nullable: true })
+  @Field(_type => String, { nullable: true })
   public startCursor: string | null;
 
-  @GQL.Field(_type => String, { nullable: true })
+  @Field(_type => String, { nullable: true })
   public endCursor: string | null;
 
-  @GQL.Field(_type => GQL.Int, { nullable: true })
+  @Field(_type => Int, { nullable: true })
   public totalEdges?: number | null;
 }

--- a/test/BarConnection.ts
+++ b/test/BarConnection.ts
@@ -1,0 +1,87 @@
+import {
+  ConnectionArgs,
+  ConnectionBuilder,
+  ConnectionInterface,
+  createConnectionType,
+  createEdgeType,
+  Cursor,
+  EdgeInputWithCursor,
+  EdgeInterface,
+  PageInfo,
+  validateParamsUsingSchema,
+} from '../src';
+import Joi from 'joi';
+import { createUnionType } from '@nestjs/graphql';
+import { Initializable } from 'ts-class-initializable';
+
+export class FruitBar extends Initializable<FruitBar> {
+  id: string;
+  name: string;
+  sugars: number;
+}
+
+export class NutBar extends Initializable<NutBar> {
+  id: string;
+  name: string;
+  protein: number;
+}
+
+export const BarUnion = createUnionType({
+  name: 'BarUnion',
+  types: () => [FruitBar, NutBar],
+});
+
+export interface BarEdgeInterface extends EdgeInterface<typeof BarUnion> {
+  customEdgeField?: number;
+}
+
+export class BarEdge extends createEdgeType<BarEdgeInterface>(BarUnion) implements BarEdgeInterface {
+  public customEdgeField?: number;
+}
+
+export interface BarConnectionInterface extends ConnectionInterface<BarEdge> {
+  customConnectionField?: number;
+}
+
+export class BarConnection
+  extends createConnectionType<BarConnectionInterface>(BarEdge)
+  implements BarConnectionInterface
+{
+  public customConnectionField?: number;
+}
+
+export class BarConnectionArgs extends ConnectionArgs {
+  public sortOption?: string;
+}
+
+export type BarCursorParams = { id?: string };
+
+export type BarCursor = Cursor<BarCursorParams>;
+
+export class BarConnectionBuilder extends ConnectionBuilder<
+  BarConnection,
+  BarConnectionArgs,
+  BarEdge,
+  typeof BarUnion,
+  BarCursor
+> {
+  public createConnection(fields: { edges: BarEdge[]; pageInfo: PageInfo }): BarConnection {
+    return new BarConnection(fields);
+  }
+
+  public createEdge(fields: EdgeInputWithCursor<BarEdge>): BarEdge {
+    return new BarEdge(fields);
+  }
+
+  public createCursor(node: typeof BarUnion): BarCursor {
+    return new Cursor({ id: node.id });
+  }
+
+  public decodeCursor(encodedString: string): BarCursor {
+    const schema: Joi.ObjectSchema<BarCursorParams> = Joi.object({
+      id: Joi.string().empty('').required(),
+    }).unknown(false);
+
+    return Cursor.fromString(encodedString, params => validateParamsUsingSchema(params, schema));
+  }
+}

--- a/test/FooConnection.ts
+++ b/test/FooConnection.ts
@@ -1,0 +1,67 @@
+import {
+  ConnectionArgs,
+  ConnectionBuilder,
+  ConnectionInterface,
+  createConnectionType,
+  createEdgeType,
+  Cursor,
+  EdgeInputWithCursor,
+  EdgeInterface,
+  PageInfo,
+  validateParamsUsingSchema,
+} from '../src';
+import Joi from 'joi';
+import { Initializable } from 'ts-class-initializable';
+
+export class Foo extends Initializable<Foo> {
+  id: string;
+  name: string;
+}
+
+export interface FooEdgeInterface extends EdgeInterface<Foo> {
+  customEdgeField?: number;
+}
+
+export class FooEdge extends createEdgeType<FooEdgeInterface>(Foo) implements FooEdgeInterface {
+  public customEdgeField?: number;
+}
+
+export interface FooConnectionInterface extends ConnectionInterface<FooEdge> {
+  customConnectionField?: number;
+}
+
+export class FooConnection
+  extends createConnectionType<FooConnectionInterface>(FooEdge)
+  implements FooConnectionInterface
+{
+  public customConnectionField?: number;
+}
+
+export class FooConnectionArgs extends ConnectionArgs {
+  public sortOption?: string;
+}
+
+export type FooCursorParams = { id?: string; name?: string };
+export type FooCursor = Cursor<FooCursorParams>;
+
+export class FooConnectionBuilder extends ConnectionBuilder<FooConnection, FooConnectionArgs, FooEdge, Foo, FooCursor> {
+  public createConnection(fields: { edges: FooEdge[]; pageInfo: PageInfo }): FooConnection {
+    return new FooConnection(fields);
+  }
+
+  public createEdge(fields: EdgeInputWithCursor<FooEdge>): FooEdge {
+    return new FooEdge(fields);
+  }
+
+  public createCursor(node: Foo): FooCursor {
+    return new Cursor({ id: node.id });
+  }
+
+  public decodeCursor(encodedString: string): FooCursor {
+    const schema: Joi.ObjectSchema<FooCursorParams> = Joi.object({
+      id: Joi.string().empty('').required(),
+    }).unknown(false);
+
+    return Cursor.fromString(encodedString, params => validateParamsUsingSchema(params, schema));
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
   "extends": "./tsconfig.json",
   "exclude": ["node_modules", "test", "**/*.spec.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,11 +15,11 @@
     "preserveConstEnums": true,
     "strictNullChecks": true,
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "./",
     "baseUrl": "./",
     "paths": {},
     "typeRoots": ["./node_modules/@types", "./@types"]
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Fixes #404 

`createEdgeType()` no longer requires a concrete class for your Nodes. Any graphql type reference will now work, including union types.